### PR TITLE
Fix AttributeError: 'str' object has no attribute 'type' in device type check

### DIFF
--- a/xrfm/rfm_src/recursive_feature_machine.py
+++ b/xrfm/rfm_src/recursive_feature_machine.py
@@ -237,7 +237,7 @@ class RFM(torch.nn.Module):
 
         if mem_gb is not None:
             self.mem_gb = mem_gb
-        elif device.type == "cuda":
+        elif self.device.type == "cuda":
             # find GPU memory in GB, keeping aside 1GB for safety
             self.mem_gb = torch.cuda.get_device_properties(self.device).total_memory//1024**3 - 1 
         else:


### PR DESCRIPTION
**Bug Fix**: Fixed AttributeError when checking device type for CUDA memory allocation.

**Issue**: The code was trying to access `.type` attribute on the original `device` string parameter instead of the converted `torch.device` object.

**Solution**: Changed `device.type == "cuda"` to `self.device.type == "cuda"` on line 240, using the properly converted device object that has the `.type` attribute.

**Impact**: Resolves the AttributeError that occurs when initializing RFM with a string device parameter.